### PR TITLE
Develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# Ambiente Virtual
+venv/
+.env
+
+# Arquivos de configuração e credenciais
+*.env
+alembic.ini
+
+# Arquivos de cache
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Configurações do editor de código
+.vscode/
+.idea/
+
+# Logs
+*.log
+
+# Arquivos de debug e temporários do sistema
+*.DS_Store
+*.swp
+*.swo
+*.tmp
+
+# Arquivos de output
+*.out
+
+# Arquivos de banco de dados local (caso tenha algum)
+*.sqlite3
+
+# Pasta de migrations automáticas do Alembic
+migrations/versions/
+
+# Outros arquivos e diretórios comuns a serem ignorados
+*.egg-info/
+dist/
+build/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,88 @@
+# 🌐 FastAPI & PostGIS Backend with GeoServer
+
+This project provides a FastAPI backend for geospatial data, integrated with **PostGIS** for spatial database support and **GeoServer** for advanced geospatial services. This backend can be used with a client application, such as the [OpenLayers Angular Map Project](https://github.com/JosephAbdayem/openlayers-angular), to serve and visualize spatial data.
+
+## 📋 Prerequisites
+
+Ensure the following dependencies are installed:
+
+- **Docker**: For containerization.
+- **Docker Compose**: To manage multi-container Docker applications.
+- **FastAPI**: Installed and configured within the Docker container.
+
+## ⚙️ Setup Instructions
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/JosephAbdayem/postgis-server.git
+cd postgis-server
+```
+
+### 2. Start the Docker Containers
+
+Use Docker Compose to build and run the containers. This command sets up the FastAPI application, PostgreSQL with PostGIS, and GeoServer.
+
+```bash
+docker-compose up --build
+```
+
+- `--build` ensures fresh images are built for any recent code changes.
+- The FastAPI API will be available at `http://localhost:8000`.
+- GeoServer will be accessible at `http://localhost:8080`.
+
+### 3. Access API Documentation and GeoServer
+
+- **FastAPI Swagger UI**: [http://localhost:8000/docs](http://localhost:8000/docs)
+- **FastAPI ReDoc**: [http://localhost:8000/redoc](http://localhost:8000/redoc)
+- **GeoServer**: [http://localhost:8080](http://localhost:8080)
+
+## 🚀 Usage
+
+- **PostGIS Database**: A spatial database in PostgreSQL with PostGIS support.
+- **GeoServer**: Provides a web interface for managing and publishing geospatial data as WMS/WFS services.
+- **API Endpoints**: The FastAPI backend provides endpoints for CRUD operations on geospatial data stored in PostGIS.
+
+### Example API Request
+
+To retrieve geospatial data:
+
+```http
+GET /geodata
+```
+
+Additional endpoints can be explored in the Swagger UI or ReDoc interfaces.
+
+## 🔄 Customization
+
+- **Database Configuration**: Environment variables (e.g., username, password, and database name) can be adjusted in `docker-compose.yml`.
+- **GeoServer**: Adjust GeoServer settings within its admin interface or configure WMS layers as needed.
+
+## 🛠 Project Structure
+
+- **FastAPI**: Acts as the main API framework.
+- **PostGIS/PostgreSQL**: Provides spatial capabilities to the database.
+- **GeoServer**: Handles web map services (WMS) and web feature services (WFS) for visualizing geospatial data.
+- **Docker Compose**: Manages multi-container applications to isolate and control each service.
+
+## 🐋 Docker Commands
+
+To stop the Docker containers:
+
+```bash
+docker-compose down
+```
+
+To clean up all stopped containers and images:
+
+```bash
+docker system prune -a
+```
+
+## 💬 Issues and Contributions
+
+Feel free to open issues for any bugs or feature requests. Contributions are welcome through pull requests to help improve the project!
+
+## 📜 License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,12 @@
+import os
+import importlib
+
+# Carrega automaticamente todos os módulos na pasta models
+models_dir = os.path.dirname(__file__)
+for module_name in os.listdir(models_dir):
+    if module_name.endswith(".py") and module_name != "__init__.py":
+        module_name = module_name[:-3]  # Remove o sufixo '.py'
+        try:
+            importlib.import_module(f"app.models.{module_name}")
+        except ModuleNotFoundError as e:
+            print(f"Erro ao importar o módulo {module_name}: {e}")

--- a/app/db/database.py
+++ b/app/db/database.py
@@ -1,0 +1,9 @@
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = "postgresql+psycopg2://geoserver:geoserver_password@postgres:5432/geodata"
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,12 @@
+from fastapi import FastAPI
+from .db.database import engine, Base
+import app.models
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+
+
+@app.get("/")
+def read_root():
+    return {"Hello": "World"}

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,13 @@
+import os
+import importlib
+
+models_dir = os.path.dirname(__file__)
+
+for module_name in os.listdir(models_dir):
+    if module_name.endswith(".py") and module_name != "__init__.py":
+        module_name = module_name[:-3]  # Remove o sufixo '.py'
+        try:
+            module = importlib.import_module(f"app.models.{module_name}")
+            globals()[module_name] = module
+        except ImportError as e:
+            print(f"Erro ao importar o módulo {module_name}: {e}")

--- a/app/models/point.py
+++ b/app/models/point.py
@@ -1,0 +1,11 @@
+from sqlalchemy import Column, Integer, String
+from geoalchemy2 import Geometry
+from app.db.database import Base
+
+
+class Point(Base):
+    __tablename__ = 'point'
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    geom = Column(Geometry(geometry_type='POINT', srid=4326))

--- a/app/models/polygon.py
+++ b/app/models/polygon.py
@@ -1,0 +1,11 @@
+from sqlalchemy import Column, Integer, String
+from geoalchemy2 import Geometry
+from app.db.database import Base
+
+
+class Polygon(Base):
+    __tablename__ = 'polygon'
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    geom = Column(Geometry(geometry_type='POLYGON', srid=4326))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   postgres:
     image: postgis/postgis:latest
-    container_name: postgres
     environment:
       POSTGRES_USER: geoserver
       POSTGRES_PASSWORD: geoserver_password
@@ -13,7 +12,6 @@ services:
 
   geoserver:
     image: oscarfonts/geoserver:latest
-    container_name: geoserver
     networks:
       - geoserver_network
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  postgres:
+    image: postgis/postgis:latest
+    container_name: postgres
+    environment:
+      POSTGRES_USER: geoserver
+      POSTGRES_PASSWORD: geoserver_password
+      POSTGRES_DB: geodata
+    networks:
+      - geoserver_network
+    ports:
+      - "5432:5432"
+
+  geoserver:
+    image: oscarfonts/geoserver:latest
+    container_name: geoserver
+    networks:
+      - geoserver_network
+    ports:
+      - "8080:8080"
+    depends_on:
+      - postgres
+
+networks:
+  geoserver_network:
+    driver: bridge

--- a/migrations/README
+++ b/migrations/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,52 @@
+import geoalchemy2
+from logging.config import fileConfig
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+from app.db.database import Base
+from app import models
+from geoalchemy2 import Geometry
+
+config = context.config
+fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+    url = config.get_main_option("sqlalchemÍy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        render_as_batch=True  # Suporte para batch se necessário
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            render_as_batch=True
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,27 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import geoalchemy2
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi[all]
+sqlalchemy
+alembic
+geoalchemy2
+psycopg2-binary


### PR DESCRIPTION
### PR Summary: Add Docker Compose Configuration for PostGIS and GeoServer Services

#### Description:
This pull request introduces a `docker-compose.yml` file to streamline the setup of the **PostGIS** and **GeoServer** services. These additions enhance the backend environment by enabling geospatial data management with PostGIS, alongside map publishing and WMS/WFS services via GeoServer.

#### Key Additions:
- **PostGIS Service**:
  - Image: `postgis/postgis:latest`
  - Configured with environment variables for the database (`POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB`).
  - Exposes port `5432` for database connections.
  - Connected to a dedicated Docker network (`geoserver_network`) to facilitate secure communication with GeoServer.
  
- **GeoServer Service**:
  - Image: `oscarfonts/geoserver:latest`
  - Configured to depend on the PostGIS service, ensuring database availability before GeoServer starts.
  - Exposes port `8080` for accessing the GeoServer web interface.
  - Connected to the same `geoserver_network` as PostGIS.

- **Network Configuration**:
  - Defined `geoserver_network` as a Docker bridge network to isolate and manage internal communication between the services.

#### Impact:
This addition simplifies the setup of geospatial services required for backend development, enabling seamless integration with projects relying on spatial data processing and map services, such as the [OpenLayers Angular Map Project](https://github.com/JosephAbdayem/openlayers-angular).

#### Usage:
Developers can initialize both services simultaneously by running:

```bash
docker-compose up --build
```

This will start the PostGIS and GeoServer containers, which are accessible at `localhost:5432` and `localhost:8080`, respectively.